### PR TITLE
Fixes markdown heading in CodingStyle.md

### DIFF
--- a/docs/development/CodingStyle.md
+++ b/docs/development/CodingStyle.md
@@ -89,7 +89,8 @@ if (x is true) {
 }
 ```
 
-###Braces are required
+### Braces are required
+
 Omission of "unnecessary" braces in cases where an `if` or `else` block consists only of a single statement is not permissible in any case. These "single statement blocks" are future bugs waiting to happen when more statements are added without enclosing the block in braces.
 
 ## Spaces


### PR DESCRIPTION
This adds a space after `###` for the "Braces are required" heading, so it is rendered correctly on betaflight.com/docs/development/CodingStyle.  

It also adds an empty line after the heading, consistent with the other headings in the file.